### PR TITLE
Bring all changes from branches `v412-with-better-errors` and `v412-tc` to the `main`

### DIFF
--- a/createsend.gemspec
+++ b/createsend.gemspec
@@ -1,6 +1,3 @@
-require 'bundler'
-require 'bundler/version'
-
 require File.expand_path('lib/createsend/version')
 
 Gem::Specification.new do |s|

--- a/lib/createsend/createsend.rb
+++ b/lib/createsend/createsend.rb
@@ -31,7 +31,13 @@ module CreateSend
   # Raised for HTTP response code of 404
   class NotFound < ClientError; end
   # Raised for HTTP response code of 429
-  class TooManyRequests < ClientError; end
+  class TooManyRequests < ClientError
+    attr_reader :response
+
+    def initialize(response)
+      @response = response
+    end
+  end
 
   # Raised for HTTP response code of 401, specifically when an OAuth token
   # in invalid (Code: 120, Message: 'Invalid OAuth Token')
@@ -282,7 +288,7 @@ module CreateSend
       when 404
         raise NotFound.new
       when 429
-        raise TooManyRequests.new
+        raise TooManyRequests.new(response)
       when 400...500
         raise ClientError.new
       when 500...600

--- a/lib/createsend/createsend.rb
+++ b/lib/createsend/createsend.rb
@@ -30,6 +30,8 @@ module CreateSend
   class Unauthorized < CreateSendError; end
   # Raised for HTTP response code of 404
   class NotFound < ClientError; end
+  # Raised for HTTP response code of 429
+  class TooManyRequests < ClientError; end
 
   # Raised for HTTP response code of 401, specifically when an OAuth token
   # in invalid (Code: 120, Message: 'Invalid OAuth Token')
@@ -279,6 +281,8 @@ module CreateSend
         end
       when 404
         raise NotFound.new
+      when 429
+        raise TooManyRequests.new
       when 400...500
         raise ClientError.new
       when 500...600

--- a/test/createsend_test.rb
+++ b/test/createsend_test.rb
@@ -278,11 +278,12 @@ class CreateSendTest < Test::Unit::TestCase
         @template = CreateSend::Template.new @auth, '98y2e98y289dh89h938389'
       end
 
-      { ["400", "Bad Request"]  => CreateSend::BadRequest,
-        ["401", "Unauthorized"] => CreateSend::Unauthorized,
-        ["404", "Not Found"]    => CreateSend::NotFound,
-        ["418", "I'm a teapot"] => CreateSend::ClientError,
-        ["500", "Server Error"] => CreateSend::ServerError
+      { ["400", "Bad Request"]       => CreateSend::BadRequest,
+        ["401", "Unauthorized"]      => CreateSend::Unauthorized,
+        ["404", "Not Found"]         => CreateSend::NotFound,
+        ["418", "I'm a teapot"]      => CreateSend::ClientError,
+        ["429", "Too many requests"] => CreateSend::TooManyRequests,
+        ["500", "Server Error"]      => CreateSend::ServerError
       }.each do |status, exception|
         context "#{status.first}, a get" do
           should "raise a #{exception.name} error" do


### PR DESCRIPTION
CampaignMonitor has updated their `createsend-ruby` gem to version 6.0.0.

One of the features introduced in v6.0.0 is the usage of their latest API, v3.3:

https://github.com/campaignmonitor/createsend-ruby/blob/v6.0.0/HISTORY.md#v600---10-feb-2022

While this update is welcome, we made some changes to their gem which we would like to maintain.

This PR brings these changes to our fork of `campaignmonitor/createsend-ruby`.